### PR TITLE
feat(hm): add dbPath option to Home Manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ drift.
             rules = ./rules;       # directory of .md files
             defaultRules = false;   # true = auto-include in every agent thread
             prune = true;           # remove managed rules whose source is gone
+            dbPath = ./path/to/zed/prompts/prompts-library-db.0.mdb; # optional: override default DB location
           };
         }
       ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -35,11 +35,23 @@ in
       default = true;
       description = "Remove managed rules whose source .md file no longer exists.";
     };
+
+    dbPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Override the path to Zed's prompt store LMDB database. Useful for
+        Zed Preview, a custom XDG_CONFIG_HOME, or sandboxed installs. When
+        null, the CLI falls back to its default location.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
     home.activation.zedRulesSync = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      run ${cfg.package}/bin/zed-rules-sync sync ${cfg.rules} \
+      run ${cfg.package}/bin/zed-rules-sync ${
+        lib.optionalString (cfg.dbPath != null) "--db-path ${cfg.dbPath}"
+      } sync ${cfg.rules} \
         ${lib.optionalString cfg.defaultRules "--default"} \
         ${lib.optionalString cfg.prune "--prune"}
     '';


### PR DESCRIPTION
Surfaces --db-path through the module for Zed Preview / custom XDG_CONFIG_HOME users.

Closes #1