### PR TITLE
chore: post-v0.2.0 polish (checkout@v5, dbPath type)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ drift.
             rules = ./rules;       # directory of .md files
             defaultRules = false;   # true = auto-include in every agent thread
             prune = true;           # remove managed rules whose source is gone
-            dbPath = ./path/to/zed/prompts/prompts-library-db.0.mdb; # optional: override default DB location
+            # dbPath = "/home/you/.config/zed-preview/prompts/prompts-library-db.0.mdb"; # optional
           };
         }
       ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -37,12 +37,17 @@ in
     };
 
     dbPath = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
+      type = lib.types.nullOr lib.types.str;
       default = null;
+      example = "/home/you/.config/zed-preview/prompts/prompts-library-db.0.mdb";
       description = ''
-        Override the path to Zed's prompt store LMDB database. Useful for
-        Zed Preview, a custom XDG_CONFIG_HOME, or sandboxed installs. When
-        null, the CLI falls back to its default location.
+        Absolute path to Zed's prompt store LMDB database, as a string.
+        Useful for Zed Preview, a custom XDG_CONFIG_HOME, or sandboxed
+        installs. When null, the CLI falls back to its default location.
+
+        Passed as-is to the CLI at activation time, so a string is used
+        instead of a Nix path - a Nix path literal would be copied into
+        the store, which isn't what you want for a runtime target.
       '';
     };
   };


### PR DESCRIPTION
Two small follow-ups from the v0.2.0 review:

- **ci**: bump \`actions/checkout\` to v5 (Node.js 24 runtime) ahead of the June 2026 deprecation of Node.js 20 for JS actions.
- **build(hm)**: change the \`dbPath\` option from \`lib.types.nullOr lib.types.path\` to \`lib.types.nullOr lib.types.str\`. \`path\` coerces Nix path literals into the store, which is the wrong thing for a runtime DB location. Adds an \`example\` on the option and moves the README example to a commented-out string form.

No behavior change for anyone passing a string already (the common case). The only breakage is if someone was passing a Nix path literal like \`dbPath = ./foo.mdb;\`, which would have silently been copied to the store under the old type.