### PR TITLE
Add frontmatter default rule support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "zed-rules-sync"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-rules-sync"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Sync markdown rule files into Zed's Rules Library"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ zed-rules-sync sync ./rules --dry-run
 zed-rules-sync sync ./rules --recursive
 ```
 
+Rule files can override the sync-wide default setting with YAML-style
+frontmatter:
+
+```md
+---
+default: true
+---
+
+Use this rule in every new Agent Panel interaction.
+```
+
+Set `default: false` to keep a rule out of the default context even when
+running `sync --default` or setting `defaultRules = true` in Home Manager.
+The frontmatter is stripped before the rule body is written to Zed.
+
 When `--recursive` is set, subdirectories of the source path are walked for
 `.md` files. Because rule UUIDs are derived from filenames alone, two files
 with the same basename (e.g. `rules/a/foo.md` and `rules/b/foo.md`) would
@@ -213,9 +228,9 @@ for breaking changes to the prompt store.
 
 - **Restart required** — Zed caches the Rules Library in memory at startup.
   Changes made by `zed-rules-sync` are not visible until Zed is restarted.
-- **Default flag is per-rule metadata** — marking a rule as `--default` sets it
-  in the LMDB metadata. It won't retroactively apply to already-open agent
-  threads.
+- **Default flag is per-rule metadata** — marking a rule as `--default`, or
+  setting `default: true` in rule frontmatter, sets it in the LMDB metadata.
+  It won't retroactively apply to already-open agent threads.
 - **LMDB single-writer** — if Zed is actively writing to the prompt store at
   the exact moment the tool runs, the write may fail. In practice this is rare
   since Zed writes at startup and on explicit user action.

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,8 +133,7 @@ fn cmd_sync(
     for (filename, filepath) in &md_files {
         let id = prompt_id_for_filename(filename);
         let title = title_from_filename(filename);
-        let body = std::fs::read_to_string(filepath)
-            .with_context(|| format!("failed to read {}", filepath.display()))?;
+        let (rule_default, body) = parse_rule_file(filepath, default)?;
         synced.insert(filename.clone());
         let exists = db
             .as_ref()
@@ -142,13 +141,14 @@ fn cmd_sync(
             .unwrap_or(false);
         if dry_run {
             println!(
-                "  {}: {} ({})",
+                "  {}: {} ({}, default: {})",
                 if exists { "update" } else { "create" },
                 title,
-                filename
+                filename,
+                if rule_default { "yes" } else { "no" }
             );
         } else if let Some(ref db) = db {
-            db.upsert_rule(id, &title, default, &body)?;
+            db.upsert_rule(id, &title, rule_default, &body)?;
         }
         if exists {
             updated += 1;
@@ -240,6 +240,66 @@ fn cmd_remove(
     let p = if dry_run { "Would remove" } else { "Removed" };
     println!("\n{} {} rule(s).", p, removed);
     Ok(())
+}
+
+fn parse_rule_file(path: &PathBuf, fallback_default: bool) -> Result<(bool, String)> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    parse_rule_contents(&contents, fallback_default)
+        .with_context(|| format!("failed to parse frontmatter in {}", path.display()))
+}
+
+fn parse_rule_contents(contents: &str, fallback_default: bool) -> Result<(bool, String)> {
+    let Some(after_opening_delimiter) = contents
+        .strip_prefix("---\n")
+        .or_else(|| contents.strip_prefix("---\r\n"))
+    else {
+        return Ok((fallback_default, contents.to_string()));
+    };
+
+    let mut rule_default = fallback_default;
+    let mut cursor = contents.len() - after_opening_delimiter.len();
+
+    while cursor <= contents.len() {
+        let line_end = contents[cursor..]
+            .find('\n')
+            .map(|offset| cursor + offset)
+            .unwrap_or(contents.len());
+        let line = &contents[cursor..line_end];
+        let trimmed = line.trim();
+
+        if trimmed == "---" {
+            let body_start = if line_end < contents.len() {
+                line_end + 1
+            } else {
+                line_end
+            };
+            return Ok((rule_default, contents[body_start..].to_string()));
+        }
+
+        if let Some(value) = trimmed.strip_prefix("default:") {
+            let normalized = value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_ascii_lowercase();
+            rule_default = match normalized.as_str() {
+                "true" | "yes" => true,
+                "false" | "no" => false,
+                _ => anyhow::bail!(
+                    "invalid frontmatter default value {:?}; expected true or false",
+                    value.trim()
+                ),
+            };
+        }
+
+        if line_end == contents.len() {
+            break;
+        }
+        cursor = line_end + 1;
+    }
+
+    Ok((fallback_default, contents.to_string()))
 }
 
 fn collect_md_files(path: &PathBuf, recursive: bool) -> Result<Vec<(String, PathBuf)>> {
@@ -351,6 +411,45 @@ mod tests {
         let files = collect_md_files(&root.to_path_buf(), false).unwrap();
         let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
         assert_eq!(names, vec!["top.md"]);
+    }
+
+    #[test]
+    fn frontmatter_default_overrides_cli_default_and_is_stripped() {
+        let contents = "---\ndefault: true\n---\nUse this rule.\n";
+        let (default, body) = parse_rule_contents(contents, false).unwrap();
+
+        assert!(default);
+        assert_eq!(body, "Use this rule.\n");
+    }
+
+    #[test]
+    fn frontmatter_default_false_overrides_cli_default() {
+        let contents = "---\ndefault: false\n---\nUse this rule.\n";
+        let (default, body) = parse_rule_contents(contents, true).unwrap();
+
+        assert!(!default);
+        assert_eq!(body, "Use this rule.\n");
+    }
+
+    #[test]
+    fn missing_frontmatter_uses_cli_default() {
+        let contents = "Use this rule.\n";
+        let (default, body) = parse_rule_contents(contents, true).unwrap();
+
+        assert!(default);
+        assert_eq!(body, "Use this rule.\n");
+    }
+
+    #[test]
+    fn invalid_frontmatter_default_errors() {
+        let err = parse_rule_contents("---\ndefault: maybe\n---\nUse this rule.\n", false)
+            .expect_err("expected invalid default error");
+
+        assert!(
+            format!("{}", err).contains("invalid frontmatter default value"),
+            "err: {}",
+            err
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add YAML-style frontmatter parsing for per-rule default settings
- strip frontmatter before writing rule bodies to Zed
- document frontmatter usage and bump version to 0.2.2

## Testing
- devenv shell -- sh -c 'cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test'
- nix develop --command sh -c 'cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test'