### PR TITLE
ci: harden upstream drift check, add README badges

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -58,12 +58,11 @@ jobs:
             if ! echo "$STORE" | grep -q 'tag = "kind"'; then
               ISSUES="$ISSUES$NL- PromptId serde tag changed (was: kind)"
             fi
-          fi
-
-          # 3. Check DB path
-          PATHS=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/paths/src/paths.rs || true)
-          if [ -n "$PATHS" ] && ! echo "$PATHS" | grep -q 'prompts-library-db.0.mdb'; then
-            ISSUES="$ISSUES$NL- DB path may have changed (prompts-library-db.0.mdb not found in paths.rs)"
+            # DB filename — constructed in prompt_store.rs as
+            #   paths::prompts_dir().join("prompts-library-db.0.mdb")
+            if ! echo "$STORE" | grep -q 'prompts-library-db.0.mdb'; then
+              ISSUES="$ISSUES$NL- DB filename may have changed (prompts-library-db.0.mdb not found in prompt_store.rs)"
+            fi
           fi
 
           # Report

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -17,49 +17,70 @@ jobs:
         run: |
           set -euo pipefail
           ISSUES=""
+          NL=$'\n'
+
+          # Match `heed = ...` whether top-level or indented under
+          # [workspace.dependencies]. Accept 2- or 3-part versions.
+          HEED_LINE_RE='^[[:space:]]*heed[[:space:]]*='
+          VERSION_RE='[0-9]+\.[0-9]+(\.[0-9]+)?'
 
           # 1. Check heed version
-          ZED_HEED=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/Cargo.toml \
-            | grep -m1 '^heed' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          OUR_HEED=$(grep -m1 '^heed' Cargo.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-          echo "Zed heed: $ZED_HEED, ours: $OUR_HEED"
-          ZED_MAJOR=$(echo "$ZED_HEED" | cut -d. -f1-2)
-          OUR_MAJOR=$(echo "$OUR_HEED" | cut -d. -f1-2)
-          if [ "$ZED_MAJOR" != "$OUR_MAJOR" ]; then
-            ISSUES="$ISSUES\n- heed version drift: Zed=$ZED_HEED, ours=$OUR_HEED"
+          ZED_CARGO=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/Cargo.toml || true)
+          ZED_HEED=$(printf '%s\n' "$ZED_CARGO" | grep -m1 -E "$HEED_LINE_RE" | grep -oE "$VERSION_RE" | head -n1 || true)
+          OUR_HEED=$(grep -m1 -E "$HEED_LINE_RE" Cargo.toml | grep -oE "$VERSION_RE" | head -n1 || true)
+          echo "Zed heed: ${ZED_HEED:-<unknown>}, ours: ${OUR_HEED:-<unknown>}"
+          if [ -z "$ZED_HEED" ]; then
+            ISSUES="$ISSUES$NL- could not detect heed version in Zed Cargo.toml (parser may need updating)"
+          fi
+          if [ -z "$OUR_HEED" ]; then
+            ISSUES="$ISSUES$NL- could not detect heed version in our Cargo.toml (parser may need updating)"
+          fi
+          if [ -n "$ZED_HEED" ] && [ -n "$OUR_HEED" ]; then
+            ZED_MAJOR=$(echo "$ZED_HEED" | cut -d. -f1-2)
+            OUR_MAJOR=$(echo "$OUR_HEED" | cut -d. -f1-2)
+            if [ "$ZED_MAJOR" != "$OUR_MAJOR" ]; then
+              ISSUES="$ISSUES$NL- heed version drift: Zed=$ZED_HEED, ours=$OUR_HEED"
+            fi
           fi
 
-          # 2. Check schema names
-          STORE=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/prompt_store/src/prompt_store.rs)
-          if ! echo "$STORE" | grep -q '"metadata.v2"'; then
-            ISSUES="$ISSUES\n- metadata.v2 no longer found in prompt_store.rs"
-          fi
-          if ! echo "$STORE" | grep -q '"bodies.v2"'; then
-            ISSUES="$ISSUES\n- bodies.v2 no longer found in prompt_store.rs"
+          # 2. Check schema names + PromptId shape
+          STORE=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/prompt_store/src/prompt_store.rs || true)
+          if [ -z "$STORE" ]; then
+            ISSUES="$ISSUES$NL- could not fetch prompt_store.rs (file may have moved or been renamed)"
+          else
+            if ! echo "$STORE" | grep -q '"metadata.v2"'; then
+              ISSUES="$ISSUES$NL- metadata.v2 no longer found in prompt_store.rs"
+            fi
+            if ! echo "$STORE" | grep -q '"bodies.v2"'; then
+              ISSUES="$ISSUES$NL- bodies.v2 no longer found in prompt_store.rs"
+            fi
+            # PromptId shape: tag = "kind", User + BuiltIn variants
+            if ! echo "$STORE" | grep -q 'tag = "kind"'; then
+              ISSUES="$ISSUES$NL- PromptId serde tag changed (was: kind)"
+            fi
           fi
 
-          # 3. Check PromptId shape (tag = "kind", User + BuiltIn variants)
-          if ! echo "$STORE" | grep -q 'tag = "kind"'; then
-            ISSUES="$ISSUES\n- PromptId serde tag changed (was: kind)"
-          fi
-
-          # 4. Check DB path
-          PATHS=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/paths/src/paths.rs || echo "")
+          # 3. Check DB path
+          PATHS=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/paths/src/paths.rs || true)
           if [ -n "$PATHS" ] && ! echo "$PATHS" | grep -q 'prompts-library-db.0.mdb'; then
-            ISSUES="$ISSUES\n- DB path may have changed (prompts-library-db.0.mdb not found in paths.rs)"
+            ISSUES="$ISSUES$NL- DB path may have changed (prompts-library-db.0.mdb not found in paths.rs)"
           fi
 
           # Report
           if [ -n "$ISSUES" ]; then
             echo "::warning::Upstream drift detected"
-            echo "$ISSUES"
+            printf '%s\n' "$ISSUES"
             {
               echo "The weekly upstream check found potential breaking changes in Zed:"
               echo ""
-              echo "$ISSUES"
+              printf '%s\n' "$ISSUES"
               echo ""
               echo "Upstream source: https://github.com/zed-industries/zed/blob/main/crates/prompt_store/src/prompt_store.rs"
             } > /tmp/issue-body.md
+            gh label create upstream \
+              --color ededed \
+              --description "Tracks Zed upstream drift" \
+              --force
             gh issue create \
               --title "Upstream drift: Zed prompt_store may have changed" \
               --body-file /tmp/issue-body.md \

--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 9 * * 1" # Weekly on Monday 9am UTC
   workflow_dispatch: # Manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-zed-upstream:
     runs-on: ubuntu-latest
@@ -24,8 +28,18 @@ jobs:
           HEED_LINE_RE='^[[:space:]]*heed[[:space:]]*='
           VERSION_RE='[0-9]+\.[0-9]+(\.[0-9]+)?'
 
+          # Pin the Zed SHA at run time so the issue body's permalinks
+          # stay valid even after Zed pushes new commits to main.
+          ZED_SHA=$(curl -sf https://api.github.com/repos/zed-industries/zed/commits/main \
+            -H "Accept: application/vnd.github+json" \
+            | grep -oE '"sha":[[:space:]]*"[a-f0-9]{40}"' \
+            | head -n1 \
+            | grep -oE '[a-f0-9]{40}' || true)
+          ZED_REF=${ZED_SHA:-main}
+          echo "Pinned Zed ref: $ZED_REF"
+
           # 1. Check heed version
-          ZED_CARGO=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/Cargo.toml || true)
+          ZED_CARGO=$(curl -sf "https://raw.githubusercontent.com/zed-industries/zed/$ZED_REF/Cargo.toml" || true)
           ZED_HEED=$(printf '%s\n' "$ZED_CARGO" | grep -m1 -E "$HEED_LINE_RE" | grep -oE "$VERSION_RE" | head -n1 || true)
           OUR_HEED=$(grep -m1 -E "$HEED_LINE_RE" Cargo.toml | grep -oE "$VERSION_RE" | head -n1 || true)
           echo "Zed heed: ${ZED_HEED:-<unknown>}, ours: ${OUR_HEED:-<unknown>}"
@@ -35,55 +49,103 @@ jobs:
           if [ -z "$OUR_HEED" ]; then
             ISSUES="$ISSUES$NL- could not detect heed version in our Cargo.toml (parser may need updating)"
           fi
+          HEED_DRIFT=0
           if [ -n "$ZED_HEED" ] && [ -n "$OUR_HEED" ]; then
             ZED_MAJOR=$(echo "$ZED_HEED" | cut -d. -f1-2)
             OUR_MAJOR=$(echo "$OUR_HEED" | cut -d. -f1-2)
             if [ "$ZED_MAJOR" != "$OUR_MAJOR" ]; then
               ISSUES="$ISSUES$NL- heed version drift: Zed=$ZED_HEED, ours=$OUR_HEED"
+              HEED_DRIFT=1
             fi
           fi
 
-          # 2. Check schema names + PromptId shape
-          STORE=$(curl -sf https://raw.githubusercontent.com/zed-industries/zed/main/crates/prompt_store/src/prompt_store.rs || true)
+          # 2. Check schema names + PromptId shape + DB filename
+          STORE=$(curl -sf "https://raw.githubusercontent.com/zed-industries/zed/$ZED_REF/crates/prompt_store/src/prompt_store.rs" || true)
           if [ -z "$STORE" ]; then
             ISSUES="$ISSUES$NL- could not fetch prompt_store.rs (file may have moved or been renamed)"
           else
-            if ! echo "$STORE" | grep -q '"metadata.v2"'; then
-              ISSUES="$ISSUES$NL- metadata.v2 no longer found in prompt_store.rs"
-            fi
-            if ! echo "$STORE" | grep -q '"bodies.v2"'; then
-              ISSUES="$ISSUES$NL- bodies.v2 no longer found in prompt_store.rs"
-            fi
-            # PromptId shape: tag = "kind", User + BuiltIn variants
-            if ! echo "$STORE" | grep -q 'tag = "kind"'; then
-              ISSUES="$ISSUES$NL- PromptId serde tag changed (was: kind)"
-            fi
-            # DB filename — constructed in prompt_store.rs as
-            #   paths::prompts_dir().join("prompts-library-db.0.mdb")
-            if ! echo "$STORE" | grep -q 'prompts-library-db.0.mdb'; then
-              ISSUES="$ISSUES$NL- DB filename may have changed (prompts-library-db.0.mdb not found in prompt_store.rs)"
-            fi
+            echo "$STORE" | grep -q '"metadata.v2"' \
+              || ISSUES="$ISSUES$NL- metadata.v2 no longer found in prompt_store.rs"
+            echo "$STORE" | grep -q '"bodies.v2"' \
+              || ISSUES="$ISSUES$NL- bodies.v2 no longer found in prompt_store.rs"
+            echo "$STORE" | grep -q 'tag = "kind"' \
+              || ISSUES="$ISSUES$NL- PromptId serde tag changed (was: kind)"
+            echo "$STORE" | grep -q 'prompts-library-db.0.mdb' \
+              || ISSUES="$ISSUES$NL- DB filename may have changed (prompts-library-db.0.mdb not found in prompt_store.rs)"
           fi
 
           # Report
-          if [ -n "$ISSUES" ]; then
-            echo "::warning::Upstream drift detected"
-            printf '%s\n' "$ISSUES"
-            {
-              echo "The weekly upstream check found potential breaking changes in Zed:"
-              echo ""
-              printf '%s\n' "$ISSUES"
-              echo ""
-              echo "Upstream source: https://github.com/zed-industries/zed/blob/main/crates/prompt_store/src/prompt_store.rs"
-            } > /tmp/issue-body.md
-            gh label create upstream \
-              --color ededed \
-              --description "Tracks Zed upstream drift" \
-              --force
-            gh issue create \
-              --title "Upstream drift: Zed prompt_store may have changed" \
-              --body-file /tmp/issue-body.md \
-              --label "upstream"
-          else
+          if [ -z "$ISSUES" ]; then
             echo "All clear — no upstream drift detected."
+            exit 0
           fi
+
+          echo "::warning::Upstream drift detected"
+          printf '%s\n' "$ISSUES"
+
+          ZED_BLOB="https://github.com/zed-industries/zed/blob/$ZED_REF"
+          {
+            echo "The upstream check found potential breaking changes in Zed."
+            echo ""
+            echo "**Zed pinned at:** [\`${ZED_REF:0:12}\`]($ZED_BLOB)"
+            echo "**Last checked:** $(date -u +'%Y-%m-%d %H:%M UTC')"
+            echo ""
+            echo "## Detected drift"
+            printf '%s\n' "$ISSUES"
+            echo ""
+            echo "## Versions"
+            echo ""
+            echo "| | ours | Zed |"
+            echo "|---|---|---|"
+            echo "| heed | \`${OUR_HEED:-<unknown>}\` | \`${ZED_HEED:-<unknown>}\` |"
+            echo ""
+            echo "## Upstream sources"
+            echo ""
+            echo "- [\`Cargo.toml\`]($ZED_BLOB/Cargo.toml)"
+            echo "- [\`crates/prompt_store/src/prompt_store.rs\`]($ZED_BLOB/crates/prompt_store/src/prompt_store.rs)"
+            echo "- [Zed releases](https://github.com/zed-industries/zed/releases)"
+            echo ""
+            if [ "$HEED_DRIFT" = "1" ]; then
+              echo "## Suggested commands (heed bump)"
+              echo ""
+              echo '```sh'
+              echo "# Edit Cargo.toml: heed = \"$ZED_HEED\""
+              echo "cargo update -p heed --precise $ZED_HEED"
+              echo "cargo build"
+              echo "cargo test"
+              echo "nix build .#default"
+              echo '```'
+              echo ""
+            fi
+            echo "## Before merging"
+            echo ""
+            echo "- [ ] Verified the drift type and resolution path"
+            echo "- [ ] heed pin in \`Cargo.toml\` updated to match Zed (if heed drift)"
+            echo "- [ ] \`cargo build && cargo test\` passes"
+            echo "- [ ] \`nix build .#default\` passes"
+            echo "- [ ] **Tested against a real Zed prompt DB** (CLAUDE.md invariant — silent heed bumps can corrupt user data)"
+            echo "- [ ] Version bump in \`Cargo.toml\` per release discipline"
+            echo "- [ ] Tag created and GitHub release published with migration notes"
+          } > /tmp/issue-body.md
+
+          # Idempotent label.
+          gh label create upstream \
+            --color ededed \
+            --description "Tracks Zed upstream drift" \
+            --force >/dev/null
+
+          # Dedupe: update the existing open tracking issue if one exists,
+          # otherwise create a new one. Keeps a single thread per drift episode.
+          TITLE="Upstream drift: Zed prompt_store may have changed"
+          EXISTING=$(gh issue list --label upstream --state open --limit 1 \
+            --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing tracking issue #$EXISTING"
+            gh issue edit "$EXISTING" --title "$TITLE" --body-file /tmp/issue-body.md
+          else
+            echo "Opening new tracking issue"
+            gh issue create --title "$TITLE" --body-file /tmp/issue-body.md --label "upstream"
+          fi
+
+          # Fail the run so the README badge turns red while drift persists.
+          exit 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # zed-rules-sync
 
+[![CI](https://github.com/tmcinerney/zed-rules-sync/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tmcinerney/zed-rules-sync/actions/workflows/ci.yml)
+[![Upstream compatibility](https://github.com/tmcinerney/zed-rules-sync/actions/workflows/upstream-check.yml/badge.svg)](https://github.com/tmcinerney/zed-rules-sync/actions/workflows/upstream-check.yml)
+[![Latest release](https://img.shields.io/github/v/release/tmcinerney/zed-rules-sync)](https://github.com/tmcinerney/zed-rules-sync/releases/latest)
+[![License: MIT](https://img.shields.io/github/license/tmcinerney/zed-rules-sync)](LICENSE)
+
 Sync markdown rule files into Zed's Rules Library from the command line.
 
 ## Why


### PR DESCRIPTION
Four commits, all in `.github/workflows/upstream-check.yml` and `README.md`. Build outputs are unaffected (excluded from the flake build via `craneLib.cleanCargoSource`), so per CLAUDE.md no version tag is needed.

## Commits

### `f21187e` — harden the drift check against false aborts

Two extraction assumptions had broken silently, causing the script to abort under `set -euo pipefail` instead of reporting drift:

- Zed moved `heed` into `[workspace.dependencies]`, so the indented line no longer matches `^heed`.
- Our `Cargo.toml` pins `heed = "0.20"` (two-part), but the version regex required three parts.

Either failure short-circuited the script before any drift was recorded. The alert path also relied on a non-existent `upstream` label.

Fix: match `heed` at any indentation, accept 2- or 3-part versions, fail-soft on each extraction (empty result becomes a reported drift line), and create the `upstream` label idempotently.

### `b68d557` — add README badges

Four badges at the top of the README: CI status (`?branch=main`), Upstream compatibility, latest release, and license. Skipped the release-workflow badge (duplicates "latest release") and Dependabot auto-merge (internal noise).

### `b65b1c2` — fix DB-filename check (false positive)

Zed constructs the LMDB filename inline in `prompt_store.rs` as `paths::prompts_dir().join("prompts-library-db.0.mdb")`. `paths.rs` itself never names the `.mdb` file. The previous check grepped `paths.rs` and would have raised a false-positive drift alert on every run after the hardening commit. Now greps `prompt_store.rs`, which we already fetch.

### `151a197` — enrich drift report, dedupe issues, fail on drift

Three behaviour changes aimed at making detected drift more visible and more actionable:

- **Red badge on drift.** The job now exits non-zero when drift is detected, after opening/updating the issue, so the README upstream-check badge turns red while drift persists.
- **Single tracking issue.** `gh issue list --label upstream --state open` is consulted; if a tracking issue exists it's edited in place. Previously a fresh issue opened every Monday for the same drift.
- **Pinned-SHA permalinks + maintainer-ready body.** The Zed `main` SHA is resolved at run time and used for every fetch and link, so the body's permalinks don't rot. Body now includes a versions table, links to Zed's `Cargo.toml` and `prompt_store.rs` at the pinned SHA, the exact `cargo update -p heed --precise X` block (only when heed drifts), and a checklist surfacing the CLAUDE.md invariants — including "test against a real prompt DB" so the auto-bump path stays explicitly off-limits.

Adds an explicit `permissions:` block (`contents: read`, `issues: write`) so the `gh` calls don't depend on default token scope. The workflow does **not** auto-apply heed bumps or open draft PRs — per CLAUDE.md, heed pins must be human-verified against a real prompt DB.

## Verified end-to-end

- Manual `workflow_dispatch` run on this branch: [25060312227](https://github.com/tmcinerney/zed-rules-sync/actions/runs/25060312227/job/73412121087). Job exits 1 (intentional, → red badge), opens [#15](https://github.com/tmcinerney/zed-rules-sync/issues/15) with the rendered body (pinned SHA `16daaa7fe197`, `0.20 → 0.21.0` heed drift, suggested commands, checklist).
- All four badge URLs return HTTP 200.
- Bash logic smoke-tested locally against live Zed sources before each commit.

The first issue this opens (#15) is a real signal: Zed bumped heed `0.20 → 0.21.0`. Resolving that drift is a separate change — gated on real-DB testing per CLAUDE.md and warrants a version bump + tag.