### PR TITLE
Upgrade heed dependency to 0.21 and bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,9 +299,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
-version = "0.20.5"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4f449bab7320c56003d37732a917e18798e2f1709d80263face2b4f9436ddb"
+checksum = "bd54745cfacb7b97dee45e8fdb91814b62bccddb481debb7de0f9ee6b7bf5b43"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -324,9 +324,9 @@ checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
 
 [[package]]
 name = "heed-types"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3f528b053a6d700b2734eabcd0fd49cb8230647aa72958467527b0b7917114"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "zed-rules-sync"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "zed-rules-sync"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Sync markdown rule files into Zed's Rules Library"
 license = "MIT"
 repository = "https://github.com/tmcinerney/zed-rules-sync"
 
 [dependencies]
-heed = "0.20"
+heed = "0.21"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary
This PR updates the heed database library dependency from version 0.20 to 0.21, and bumps the package version to 0.3.0 to reflect this dependency upgrade.

## Changes
- Updated `heed` dependency from `0.20` to `0.21`
- Bumped package version from `0.2.2` to `0.3.0`

## Notes
The version bump to 0.3.0 indicates a minor version change, which is appropriate for a dependency upgrade that may include breaking changes or significant improvements in the heed library.

https://claude.ai/code/session_01AsejrrybAhdNrTR5EtJaj6