### PR TITLE
fix(nix): use stdenv.hostPlatform.system over deprecated system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
       });
 
       overlays.default = final: _prev: {
-        zed-rules-sync = self.packages.${final.system}.default;
+        zed-rules-sync = self.packages.${final.stdenv.hostPlatform.system}.default;
       };
 
       homeManagerModules.default = import ./nix/hm-module.nix self;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -14,8 +14,8 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = flake.packages.${pkgs.system}.default;
-      defaultText = lib.literalExpression "flake.packages.\${pkgs.system}.default";
+      default = flake.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = lib.literalExpression "flake.packages.\${pkgs.stdenv.hostPlatform.system}.default";
       description = "The zed-rules-sync package to use.";
     };
 


### PR DESCRIPTION
`pkgs.system` / `final.system` are deprecated aliases for `stdenv.hostPlatform.system`. Recent nixpkgs warns on access, and that warning shows up in every downstream build that evaluates the HM module - including on `home-manager` / `nix-darwin` activation in my dotfiles.

Swaps the package option default (+ its defaultText) and the overlay to the non-deprecated accessor. Verified `nix eval .#packages.aarch64-darwin.default` still resolves and the warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)